### PR TITLE
Data tests patch - fixed typo on ajv-format + updated package in .workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
         run: "touch dist/CNAME && echo \"data.web3privacy.info\" >> dist/CNAME"
     
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./dist
 

--- a/utils/test.js
+++ b/utils/test.js
@@ -1,5 +1,5 @@
 import Ajv from "npm:ajv@8.17.1";
-import addFormats from "npm:ajv-formats@3.O.1";
+import addFormats from "npm:ajv-formats@3.0.1";
 
 import { Engine } from "./engine.js";
 


### PR DESCRIPTION
This error was thrown in last PR commit to fix the Github Actions issues:
https://github.com/web3privacy/data/actions/runs/10537593173/job/29199162508

- found a typo of O instead of 0 in package
- reviewing the full error log also noticed that `action/github-pages-artifact@v3` has been bumped to v4 (depreciation deadline November 2024). I opted to rename the package `actions/upload-artifact@v4`