### PR TITLE
data tests patch - fixing the error within test.js

### DIFF
--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -116,6 +116,7 @@ $defs:
         type: string
       caption:
         type: string
+        pattern: '^((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)'
       country:
         type: string
         pattern: '^[a-z]{2}$'


### PR DESCRIPTION
Following up on this error:
https://github.com/web3privacy/data/actions/runs/10602350927/job/29384187270

Investigated to find that the error was because the caption entry of a speaker had many URL links within then, so breaking the configuration - added the following regex to the pattern for caption:


```
'^((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:[www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*](http://www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*)))?)'
```

Tested the regex expression in https://regex101.com/ first to ensure it worked with url format