### PR TITLE
Data tests patch - fixing regex issue in caption of speaker

### DIFF
--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -116,7 +116,6 @@ $defs:
         type: string
       caption:
         type: string
-        pattern: '^((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)'
       country:
         type: string
         pattern: '^[a-z]{2}$'

--- a/src/people/tim-bansemer.yaml
+++ b/src/people/tim-bansemer.yaml
@@ -1,4 +1,4 @@
 name: Tim Bansemer
-caption: [Aqua Protocol](https://aqua-protocol.org/)
+caption: CEO of [inblock.io](https://inblock.io)
 refs:
   twitter: tim_bansemer


### PR DESCRIPTION
In PR #9 an attempt was made to fix an error in test.js 

After some research this error came from the - symbol within the URL of one of the speakers in the data set `tim-bansemer.yaml`

With last PR I attempted to add an extended regex to the 'pattern' section of the schema, but it [failed to fix the issue within the test run pre-deployment](https://github.com/web3privacy/data/actions/runs/10603428304/job/29387729994). This is because regex uses the hyphen symbol '-' to define a range and can not work as a string entry as a result.

To fix the root of the problem an improved test.js needs to be written that can accept hyphens '-' within the entries in 'caption' field of the speakers or other entries within the database. Potentially this would meant parsing the caption field or some other workaround, or simply defining an exception to the test parameters defined in test.js

This is beyond my skill-set, so it should become a feature request.

In this current PR I revert my addition of the pattern to the index.yaml schema (so removing the regex entry) and I updated the speaker caption to not have a hyphen within the URL. Hoping the next test run will pass as a result.