### PR TITLE
Data tests patch - fixing empty country field error & improving schema regex

### DIFF
--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -63,7 +63,7 @@ $defs:
         type: string
       country:
         type: string
-        pattern: "^\\w{2}$"
+        pattern: "^[a-z]{2}$"
       place:
         type: string
       place-address:
@@ -118,7 +118,7 @@ $defs:
         type: string
       country:
         type: string
-        pattern: '^[a-z]{2}$'
+        pattern: "^[a-z]{2}$"
       refs:
         type: object
         additionalProperties: false

--- a/src/people/pie-man.yaml
+++ b/src/people/pie-man.yaml
@@ -1,5 +1,4 @@
 name: Pie Man
 caption: Cofounder of [Fairblock Network](https://www.fairblock.network/)
-country: 
 refs:
   twitter: Pememoni


### PR DESCRIPTION
Following last PR a new error appeared in the tests: https://github.com/web3privacy/data/actions/runs/10709455530/job/29694128885

Deleted the empty field under 'county' that failed the pattern test written in the schema

As such went looking more into the schema and updated the regex expression used within the schema to test for two letter country codes within the field. Because of how the test is coded it will fail if anything else but a 2 letter code is present in this field as a result.