### PR TITLE
Data tests patch - removed actions/artifact-upload from build process in deploy.yaml ! improved README.md

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-      steps:
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,15 +45,6 @@ jobs:
 
       - name: Add custom domain
         run: "touch dist/CNAME && echo \"data.web3privacy.info\" >> dist/CNAME"
-    
-      - name: Upload Pages artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: W3PN-artifact
-          path: ~/pre-deploy-artifact-upload/
-          if-no-files-found: warn
-          retention-days: 80
-          overwrite: true
           
   deploy:
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ on:
 
 # Allow this job to clone the repo and create a page deployment
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -48,15 +49,19 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-artifact@v4
         with:
-          path: ./dist
-
+          name: W3PN-artifact
+          path: ~/pre-deploy-artifact-upload/
+          if-no-files-found: warn
+          retention-days: 80
+          overwrite: true
+          
   deploy:
     needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    steps:
+      steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,23 +1,34 @@
 # Web3Privacy Now Data
 
 [![Build and Deploy](https://github.com/web3privacy/data/actions/workflows/deploy.yml/badge.svg)](https://github.com/web3privacy/data/actions/workflows/deploy.yml)
+[![Synchronize data](https://github.com/web3privacy/data/actions/workflows/sync.yml/badge.svg)](https://github.com/web3privacy/data/actions/workflows/sync.yml)
 
-This is a repository with structured dataset with basic informations about the [Web3Privacy Now](https://web3privacy.info/) initiative.
+This repository is the structured dataset with basic informations about the [Web3Privacy Now](https://web3privacy.info/) initiative.
 
 You can find it here:
-- Official links
-- List of team members
-- List of projects
-- List of events
+- [Web3PrivacyNow Official links and team members](https://github.com/web3privacy/data/blob/main/src/index.yaml)
+- [Web3PrivacyNow Manifesto](https://github.com/web3privacy/data/blob/main/src/W3PN%20Manifesto.png)
+- [List of projects](https://github.com/web3privacy/data/blob/main/src/projects/index.yaml)
+- [List of events](https://github.com/web3privacy/data/blob/main/src/events/index.yaml)
+- [Database of people](https://github.com/web3privacy/data/tree/main/src/people)
+- [List of research](https://github.com/web3privacy/data/blob/main/src/research/index.yaml)
 
-## Deployment
+## Deployment (JSON)
 
 * https://data.web3privacy.info/
+
+## Downstream
+
+* Once deployed to data.web3privacy.info the data is used in the deployment of the main project website [web3privacy.info](https://web3privacy.info/) - [see relevant repository](https://github.com/web3privacy/web)
 
 ## Quick links
 
 | Collection | Source | Links |
 | --- | --- | --- |
-| Core file (links, team) | [`src/index.yaml`](src/index.yaml) | [Edit](https://github.com/web3privacy/data/edit/main/src/index.yaml) |
+| Data Schema | [`schema/index.yaml`](schema/index.yaml) | [Edit](https://github.com/web3privacy/data/edit/main/schema/index.yaml) |
+| Core file | [`src/index.yaml`](src/index.yaml) | [Edit](https://github.com/web3privacy/data/edit/main/src/index.yaml) |
 | Projects | [`src/projects/index.yaml`](src/projects/index.yaml) | [Edit](https://github.com/web3privacy/data/edit/main/src/projects/index.yaml) |
 | Events | [`src/events/index.yaml`](src/events/index.yaml) | [Edit](https://github.com/web3privacy/data/edit/main/src/events/index.yaml) |
+| Research | [`src/research/index.yaml`](src/research/index.yaml) | [Edit](https://github.com/web3privacy/data/edit/main/src/research/index.yaml) |
+| People | [`src/people`](src/people/) | [Edit](https://github.com/web3privacy/data/edit/main/src/people/) |
+


### PR DESCRIPTION
The latest set of errors in the deploy.yaml script seem to indicate a deeper problem with the handling of artifacts within the Github Pages deployment. 

After some research it seems that there are issues with this within the v.4 of actions/artifact-upload that have [yet to be fully patched. ](https://github.com/actions/deploy-pages/issues/285)

I attempted to make a patch... then I considered whether this repository actually needs to use the artifacts or not. 

It seems to me to be a redundant process, since the repo is deployed to data.web3privacy.info each time the deploy.yaml script is run... so no need to have an internal artifact 'cache' as it were.

In this PR I deleted the actions/upload-artifact from the process

I also improved the README.md page and added more links to key files within.