### PR TITLE
Dependency migration - jsr@std instead of deno.land

### DIFF
--- a/src/events/index.yaml
+++ b/src/events/index.yaml
@@ -12,8 +12,8 @@
   slots: 16
   visitors: 300
   links:
+    rsvp: https://lu.ma/w3pn-meetup-devcon7
     web: https://congress.web3privacy.info/
-    git: https://github.com/web3privacy/c24bkk
   speakers:
     - ameen-soleimani
     - scott-moore

--- a/utils/engine.js
+++ b/utils/engine.js
@@ -1,8 +1,8 @@
-import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
-import { emptyDir } from "https://deno.land/std@0.224.0/fs/empty_dir.ts";
+import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
+import { emptyDir } from "jsr:@std/path@0.224.0/fs/empty_dir.ts";
 import { parse, stringify } from "npm:yaml";
-import { exists } from "https://deno.land/std@0.224.0/fs/exists.ts";
-import { copy } from "https://deno.land/std@0.224.0/fs/copy.ts";
+import { exists } from "jsr:@std/path@0.224.0/fs/exists.ts";
+import { copy } from "jsr:@std/path@0.224.0/fs/copy.ts";
 
 const SRC_DIR = "./src";
 const DEST_DIR = "./dist";

--- a/utils/engine.js
+++ b/utils/engine.js
@@ -1,8 +1,8 @@
-import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
-import { emptyDir } from "jsr:@std/path@0.224.0/fs/empty_dir.ts";
+import { join } from "jsr:@std/path@0.224.0";
+import { emptyDir } from "jsr:@std/path@0.224.0";
 import { parse, stringify } from "npm:yaml";
-import { exists } from "jsr:@std/path@0.224.0/fs/exists.ts";
-import { copy } from "jsr:@std/path@0.224.0/fs/copy.ts";
+import { exists } from "jsr:@std/fs@0.224.0";
+import { copy } from "jsr:@std/fs@0.224.0";
 
 const SRC_DIR = "./src";
 const DEST_DIR = "./dist";

--- a/utils/engine.js
+++ b/utils/engine.js
@@ -1,5 +1,5 @@
 import { join } from "jsr:@std/path@0.224.0";
-import { emptyDir } from "jsr:@std/path@0.224.0";
+import { emptyDir } from "jsr:@std/fs@0.224.0";
 import { parse, stringify } from "npm:yaml";
 import { exists } from "jsr:@std/fs@0.224.0";
 import { copy } from "jsr:@std/fs@0.224.0";

--- a/utils/images.js
+++ b/utils/images.js
@@ -1,6 +1,6 @@
 import { Engine } from "./engine.js";
-import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
-import { exists } from "jsr:@std/path@0.224.0/fs/exists.ts";
+import { join } from "jsr:@std/path@0.224.0";
+import { exists } from "jsr:@std/fs@0.224.0";
 
 const engine = new Engine();
 await engine.init();

--- a/utils/images.js
+++ b/utils/images.js
@@ -1,6 +1,6 @@
 import { Engine } from "./engine.js";
-import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
-import { exists } from "https://deno.land/std@0.224.0/fs/exists.ts";
+import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
+import { exists } from "jsr:@std/path@0.224.0/fs/exists.ts";
 
 const engine = new Engine();
 await engine.init();

--- a/utils/img-opt.js
+++ b/utils/img-opt.js
@@ -1,4 +1,4 @@
-import { run } from "jsr:@std/path@0.224.0";
+import { run } from "https://deno.land/x/run_simple@2.3.0/mod.ts";
 import { join } from "jsr:@std/path@0.224.0";
 import { emptyDir } from "jsr:@std/fs@0.224.0";
 

--- a/utils/img-opt.js
+++ b/utils/img-opt.js
@@ -1,6 +1,6 @@
-import { run } from "https://deno.land/x/run_simple@2.3.0/mod.ts";
-import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
-import { emptyDir } from "https://deno.land/std@0.224.0/fs/empty_dir.ts";
+import { run } from "jsr:@std/path@0.224.0/mod.ts";
+import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
+import { emptyDir } from "jsr:@std/path@0.224.0/fs/empty_dir.ts";
 
 async function optimizeDir (dir, sizes) {
     await emptyDir(join(dir, 'thumbs'))

--- a/utils/img-opt.js
+++ b/utils/img-opt.js
@@ -1,6 +1,6 @@
-import { run } from "jsr:@std/path@0.224.0/mod.ts";
-import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
-import { emptyDir } from "jsr:@std/path@0.224.0/fs/empty_dir.ts";
+import { run } from "jsr:@std/path@0.224.0";
+import { join } from "jsr:@std/path@0.224.0";
+import { emptyDir } from "jsr:@std/fs@0.224.0";
 
 async function optimizeDir (dir, sizes) {
     await emptyDir(join(dir, 'thumbs'))

--- a/utils/sync.js
+++ b/utils/sync.js
@@ -1,7 +1,7 @@
-import "https://deno.land/std@0.224.0/dotenv/load.ts";
-import { gql, GraphQLClient } from "https://deno.land/x/graphql_request/mod.ts";
+import "jsr:@std/path@0.224.0/dotenv/load.ts";
+import { gql, GraphQLClient } from "https://deno.land/x/graphql_request@v4.1.0/mod.ts";
 import { stringify } from "npm:yaml";
-import { join } from "https://deno.land/std@0.224.0/path/mod.ts";
+import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
 import fm from "npm:front-matter";
 
 const warningGen = (link) => `# ----

--- a/utils/sync.js
+++ b/utils/sync.js
@@ -1,7 +1,7 @@
-import "jsr:@std/path@0.224.0/dotenv/load.ts";
+import "jsr:@std/dotenv@0.224.0";
 import { gql, GraphQLClient } from "https://deno.land/x/graphql_request@v4.1.0/mod.ts";
 import { stringify } from "npm:yaml";
-import { join } from "jsr:@std/path@0.224.0/path/mod.ts";
+import { join } from "jsr:@std/path@0.224.0";
 import fm from "npm:front-matter";
 
 const warningGen = (link) => `# ----


### PR DESCRIPTION
During the [work to fix the deployment of data ](https://github.com/web3privacy/data/pull/7) I discovered that the Deno Standard Library (std) library by deno.land will be moved to JSR before the end of 2024

In preparation for this I bumped all versions of the deno.land std to 0.224.0 as noted in guide at end of blog post: https://deno.com/blog/std-on-jsr

In this PR all relevant std packages have been switched to jsr + tested it with a quick edit of c24bkk event


