### PR TITLE
Schema update - removed 'visitors' and 'slots' varibles from Events data

### DIFF
--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -78,8 +78,6 @@ $defs:
           type: string
       slots:
         type: number
-      visitors:
-        type: number
       optional:
         type: boolean
       links:

--- a/schema/index.yaml
+++ b/schema/index.yaml
@@ -76,8 +76,6 @@ $defs:
         type: array
         items:
           type: string
-      slots:
-        type: number
       optional:
         type: boolean
       links:

--- a/src/events/index.yaml
+++ b/src/events/index.yaml
@@ -11,7 +11,6 @@
   coincidence: "[DevCon](https://devcon.org)"
   lead: Mykola
   slots: 16
-  visitors: 3000
   links:
     rsvp: https://lu.ma/u2sw5kpv
     web: https://congress.web3privacy.info/
@@ -32,7 +31,6 @@
   coincidence: "[ETHRome](https://www.ethrome.org)"
   lead: Mykola
   slots: 16
-  visitors: 300
   links:
     rsvp: https://lu.ma/8jv4odjn
   speakers:
@@ -52,7 +50,6 @@
   coincidence: "Berlin Blockchain Week"
   lead: Mykola
   slots: 16
-  visitors: 300
   links:
     rsvp: https://lu.ma/gdp7vt8u
     web: https://summit.web3privacy.info/
@@ -73,7 +70,6 @@
   coincidence: "[ETHPrague](https://ethprague.com)"
   lead: Mykola
   slots: 16
-  visitors: 300
   links:
     rsvp: https://lu.ma/jhp1iapn
   speakers:
@@ -93,7 +89,6 @@
   coincidence: "[ETHDam](https://www.ethdam.com)"
   lead: Mykola
   slots: 16
-  visitors: 300
   links:
     rsvp: https://lu.ma/73go30ij
     web: https://congress.web3privacy.info
@@ -116,7 +111,6 @@
   coincidence: "[DevCon](https://devcon.org)"
   lead: Mykola
   slots: 16
-  visitors: 300
   links:
     rsvp: https://lu.ma/w3pn-meetup-devcon7
     web: https://congress.web3privacy.info
@@ -192,7 +186,6 @@
   country: cz
   coincidence: "ETHPrague"
   lead: PG
-  visitors: 180
   helpers:
     - PG
     - Mykola
@@ -235,7 +228,6 @@
     - Mykola
     - Coinmandeer
     - Robert
-  visitors: 210
   links:
     web: https://c24ber.web3privacy.info
   design:
@@ -250,7 +242,6 @@
   place-address: Rungestraße 20, 10179 Berlin
   coincidence: "ETHBerlin"
   lead: Mykola
-  visitors: 150
   helpers:
     - ligi
   speakers:
@@ -273,7 +264,6 @@
   place: "[Vrij Paleis](https://www.vrijpaleis.nl)"
   place-address: Paleisstraat 107, 1012 ZL Amsterdam
   lead: PG
-  visitors: 90
   helpers:
     - Mykola
     - Alina
@@ -299,7 +289,6 @@
   optional: true
   slots: 3
   lead: Mykola
-  visitors: 80
   design:
     image: bucharest01
   helpers:
@@ -325,7 +314,6 @@
   coincidence: "[DCxPrague](https://dcxprague.org)"
   lead: Tree
   slots: 3
-  visitors: 15
   links:
     web: https://lu.ma/w3pm-prg1
   speakers:
@@ -344,7 +332,6 @@
   coincidence: "[ETHRome](https://ethrome.org)"
   lead: PG
   slots: 10
-  visitors: 139
   links:
     web: https://lu.ma/web3privacynow_rome
   speakers:
@@ -362,7 +349,6 @@
     - carlo-chialastri
     - limone-eth
     - costanza-gallo
-    - pg
     - catsnaks
 
 - id: s23prg
@@ -376,7 +362,6 @@
   coincidence: "[ETHPrague](https://ethprague.com)"
   lead: Tree
   slots: 16
-  visitors: 180
   links:
     web: https://prague.web3privacy.info/
     git: https://github.com/web3privacy/w3ps1
@@ -400,7 +385,3 @@
     - serinko
     - steffen-kux
     - althea
-    - mykola-siusko
-    - pg
-    - tree
-

--- a/src/events/index.yaml
+++ b/src/events/index.yaml
@@ -10,7 +10,6 @@
   confirmed: true
   coincidence: "[DevCon](https://devcon.org)"
   lead: Mykola
-  slots: 16
   links:
     rsvp: https://lu.ma/u2sw5kpv
     web: https://congress.web3privacy.info/
@@ -30,7 +29,6 @@
   confirmed: true
   coincidence: "[ETHRome](https://www.ethrome.org)"
   lead: Mykola
-  slots: 16
   links:
     rsvp: https://lu.ma/8jv4odjn
   speakers:
@@ -49,7 +47,6 @@
   confirmed: true
   coincidence: "Berlin Blockchain Week"
   lead: Mykola
-  slots: 16
   links:
     rsvp: https://lu.ma/gdp7vt8u
     web: https://summit.web3privacy.info/
@@ -69,7 +66,6 @@
   confirmed: true
   coincidence: "[ETHPrague](https://ethprague.com)"
   lead: Mykola
-  slots: 16
   links:
     rsvp: https://lu.ma/jhp1iapn
   speakers:
@@ -88,7 +84,6 @@
   confirmed: true
   coincidence: "[ETHDam](https://www.ethdam.com)"
   lead: Mykola
-  slots: 16
   links:
     rsvp: https://lu.ma/73go30ij
     web: https://congress.web3privacy.info
@@ -110,7 +105,6 @@
   confirmed: true
   coincidence: "[DevCon](https://devcon.org)"
   lead: Mykola
-  slots: 16
   links:
     rsvp: https://lu.ma/w3pn-meetup-devcon7
     web: https://congress.web3privacy.info
@@ -146,7 +140,6 @@
   country: it
   coincidence: "ETHRome"
   lead: PG
-  slots: 5
   design:
     image: rome02
   helpers:
@@ -168,7 +161,6 @@
   city: Brussels
   country: be
   coincidence: "[EthCC](https://www.ethcc.io)"
-  slots: 3
   design:
     image: brussels01
   lead: Mykola
@@ -190,7 +182,6 @@
     - PG
     - Mykola
     - Coinmandeer
-  slots: 16
   links:
     rsvp: https://lu.ma/w3pn-summit-prague2
   speakers:
@@ -250,7 +241,6 @@
     - vaclav-pavlin
     - jaya-klara-brekke
     - mykola-siusko
-  slots: 4
   links:
     rsvp: https://lu.ma/w3pn-meetup-berlin1
   design:
@@ -268,7 +258,6 @@
     - Mykola
     - Alina
   coincidence: "[ETHDam](https://www.ethdam.com)"
-  slots: 3
   links:
     rsvp: https://lu.ma/w3pn-meetup-ams1
   speakers:
@@ -287,7 +276,6 @@
   country: ro
   coincidence: "[ETHBucharest](https://www.ethbucharest.xyz)"
   optional: true
-  slots: 3
   lead: Mykola
   design:
     image: bucharest01
@@ -313,7 +301,6 @@
   confirmed: true
   coincidence: "[DCxPrague](https://dcxprague.org)"
   lead: Tree
-  slots: 3
   links:
     web: https://lu.ma/w3pm-prg1
   speakers:
@@ -331,7 +318,6 @@
   confirmed: true
   coincidence: "[ETHRome](https://ethrome.org)"
   lead: PG
-  slots: 10
   links:
     web: https://lu.ma/web3privacynow_rome
   speakers:
@@ -361,7 +347,6 @@
   confirmed: true
   coincidence: "[ETHPrague](https://ethprague.com)"
   lead: Tree
-  slots: 16
   links:
     web: https://prague.web3privacy.info/
     git: https://github.com/web3privacy/w3ps1


### PR DESCRIPTION
Used in past as placeholders, with new website update these two schemas became useless. 